### PR TITLE
Enable pocl builds on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     
     - OSX_VARIANT=native
+    - OSX_VARIANT=pocl
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "gWDdW5bizc6HH3rHnQpGLA8JfBUlKhVSwZ5pU0s00mSVdWAfu7Xz3ZnSKjWstZFhRYghPQ5EinRySnDNKeCeTqMIOwFXxpHqYQq6DuLbPtgGzn8uSHNt0x+C43nyts+/WSFB24ZfyEzhmWRBng1zWc9XoJeVjmLw4Md24QHXY7qu0efr8i062bmEkB7dVDKuofWLbPQZtNRBiy+WvKnt18vLKGjmWz3x8aAQwKObBsP1lVvehjtyghoXsyLd8QjIc71vDP7GyrWL4tuzOWVP3N+mnV4FOrkSL2oDyPp2jYV1ftPd04ssjZyI6x8DZpEknTHs6P913Nh0aidyC571jqKJ+/uhNpAQSQfOi8ZcltO9IgZYrLm1UwQSVmJT8Zz+c4fl2XQ4qExMvaMBqUk75lr3/uoRu4GxnXF9CQycleip6ClDD8sGwvU84TTob/zMW6JPFxqRjBgCBbu3VFLfqvsnGe/4cc3eaASbD9rmhR+a/f3UJIu6akrRXE4YjwAH3qRUwGfqs0/ROdgpuGU2jBF+HgE/6ZLjMvowzQUQkohuCPuKe4W2uZ/TaR2JZLYqhX46DVvKyNKsqnvkt6ddLgNxchZurvSCuJvh7lBeu0MXX1UW6Nq21aywXGIxLNl47MpWOOlst2vw37jranjAGYk/vad1td8Sn05nUelkURc="

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,7 @@
 matrix:
   - []
   - [[OSX_VARIANT, 'native']]
+  - [[OSX_VARIANT, 'pocl']]
 
 travis:
   secure:


### PR DESCRIPTION
Replaces PR ( https://github.com/conda-forge/clblast-feedstock/pull/1 ).

Configures the custom matrix for `pocl` builds and enables them on macOS.